### PR TITLE
fix: prediction service url

### DIFF
--- a/src/app/services/httpClient.service.ts
+++ b/src/app/services/httpClient.service.ts
@@ -35,7 +35,7 @@ export class HttpClientService {
 
   getPrevisao(dia: number, mes: number) {
     //Exemplo http://localhost:8000/previsao/31_12
-    return this.http.get<Predicao>(this.urlPrevisao + dia + '/' + mes).toPromise();
+    return this.http.get<Predicao>(this.urlPrevisao + dia + '_' + mes).toPromise();
   }
 
   getEventos() {


### PR DESCRIPTION
# Description

Adjusted the prediction service endpoint to match the expected one in the service (https://github.com/ew3g/backend_clima/blob/53821ef27d3afee26309e26d0f6d7bdf4c967f33/main.py#L43).